### PR TITLE
fix for compatibility with OCaml 4.09

### DIFF
--- a/irr_video_wrap.cpp
+++ b/irr_video_wrap.cpp
@@ -4,7 +4,7 @@
 #include "caml/bigarray.h"
 
 void rendering_failed_exn() {
-	static value* e = NULL;
+	static value const * e = NULL;
 	if(e == NULL)
 		e = caml_named_value("Rendering_failed_exn");
 	caml_raise_constant(*e);

--- a/utils.cpp
+++ b/utils.cpp
@@ -10,7 +10,7 @@ value copy_Some(value v)
 }
 
 void null_pointer_exn() {
-	static value*  e = NULL;
+	static value const *  e = NULL;
 	if(e == NULL) {
 		e = caml_named_value("Null_pointer_exn");
 	}


### PR DESCRIPTION
In OCaml 4.09 the return type of `caml_named_value` got a `const` qualifier.

This patch makes irrlicht compatible with 4.09 while maintaining compatibility with earlier versions of OCaml.
